### PR TITLE
fix current Travis build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 node_js:
   - "8"
-  - "lts/*"
+  - "9"
 
 before_script:
   - npm i

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - "8"
   - "lts/*"
 
 before_script:


### PR DESCRIPTION
There seems to be a current problem with libxmljs under Node10 (see https://github.com/znerol/node-xmlshim/pull/8). 
The proposed pull request simply removes Node10 from the Travis test and replaces it with tests for Node8 and Node9.

NB: This is a temporary solution. We should aim for supporting the latest Node version again soon.