### PR TITLE
fix binary downloads

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -53,7 +53,7 @@ export function postToOxGarage(input, endpoint) {
       body: fd
     })
       .then(response => {
-        res(response.text())
+        res(response.blob())
       })
   })
 }


### PR DESCRIPTION
When downloading docx format (with whatever ODD) I always got defect docx files which couldn't be read by my word processor. 

This PR fixes the issue for me (and other downloads still work) although I admit I'm not 100% sure about possible side effects.

There's yet another twist to it:  RelaxNG compact (rnc) files didn't work for me either. Now (with this fix applied) they do work but hide themselves as zip archives. This in fact seems to be an OxGarage issue (again) which is already fixed in dev. 